### PR TITLE
Unreal Engine bug work-around on Linux

### DIFF
--- a/Source/HIDUE/HIDUE.Build.cs
+++ b/Source/HIDUE/HIDUE.Build.cs
@@ -12,8 +12,9 @@ public class HIDUE : ModuleRules
 
 
 		if (Target.Platform == UnrealTargetPlatform.Linux) {
-			PublicIncludePaths.AddRange(new string[] {
-				"/usr/include"
+			PrivateIncludePaths.AddRange(new string[] {
+				"/usr/include",
+				"/usr/include/x86_64-linux-gnu"
 			});
 			PublicSystemLibraries.Add("udev");
 			PublicSystemLibraryPaths.AddRange(new string[] {

--- a/Source/HIDUE/Private/Linux/hid.cpp
+++ b/Source/HIDUE/Private/Linux/hid.cpp
@@ -24,6 +24,25 @@
 #include "CoreMinimal.h"
 #if PLATFORM_LINUX
 
+/**
+ * Hack: We need to wrap these includes within an
+ *       anonymous namespace to work around an
+ *       unreal engine bug.
+ * 
+ * Bug: Unreal is getting confused between its reference to
+ * "Engine/Source/ThirdParty/Linux/LibCxx/include/c++/v1/"
+ *  and
+ * "Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v19_clang..."
+ * for includes such as 'locale.h'
+ */
+namespace {
+#ifdef LINUX_VERSION_CODE
+#undef LINUX_VERSION_CODE
+#endif
+#ifdef KERNEL_VERSION
+#undef KERNEL_VERSION
+#endif
+
 /* C */
 #include <stdio.h>
 #include <string.h>
@@ -45,6 +64,7 @@
 #include <linux/version.h>
 #include <linux/input.h>
 #include <libudev.h>
+}
 
 #include "hidapi.h"
 


### PR DESCRIPTION
Unreal Engine bug work-around on Linux. This might be avoidable if `Linux/LibCxx` can be removed from the includes list.